### PR TITLE
chore: padrao laravel/ui para arquivos frontend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "intervention/image": "^2.5",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0",
-        "laravel/ui": "^2.1",
+        "laravel/ui": "2.4",
         "spatie/laravel-permission": "3.6",
         "tplaner/when": "^3.0",
         "wgenial/numeroporextenso": "^3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "492993a1ed01c1e970ccd43c2715d290",
+    "content-hash": "5b03c8e5050aab65a4cf50ad2de6c0d2",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1307,16 +1307,16 @@
         },
         {
             "name": "laravel/ui",
-            "version": "v2.4.1",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/ui.git",
-                "reference": "1c69ae3e8b52fe6c9eaf83b43c6dd8ef5c3f9e2c"
+                "reference": "f5398544a9cd4804a42d09ce51735e37cd51ea2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/ui/zipball/1c69ae3e8b52fe6c9eaf83b43c6dd8ef5c3f9e2c",
-                "reference": "1c69ae3e8b52fe6c9eaf83b43c6dd8ef5c3f9e2c",
+                "url": "https://api.github.com/repos/laravel/ui/zipball/f5398544a9cd4804a42d09ce51735e37cd51ea2d",
+                "reference": "f5398544a9cd4804a42d09ce51735e37cd51ea2d",
                 "shasum": ""
             },
             "require": {
@@ -1358,7 +1358,7 @@
                 "laravel",
                 "ui"
             ],
-            "time": "2020-09-22T16:51:51+00:00"
+            "time": "2020-09-11T15:31:52+00:00"
         },
         {
             "name": "league/commonmark",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,19 +23,19 @@
             }
         },
         "@babel/core": {
-            "version": "7.11.1",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
-            "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
+            "version": "7.11.6",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+            "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.0",
+                "@babel/generator": "^7.11.6",
                 "@babel/helper-module-transforms": "^7.11.0",
                 "@babel/helpers": "^7.10.4",
-                "@babel/parser": "^7.11.1",
+                "@babel/parser": "^7.11.5",
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.11.0",
-                "@babel/types": "^7.11.0",
+                "@babel/traverse": "^7.11.5",
+                "@babel/types": "^7.11.5",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
@@ -47,12 +47,12 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -64,12 +64,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
-            "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+            "version": "7.11.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+            "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.11.0",
+                "@babel/types": "^7.11.5",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             }
@@ -143,12 +143,11 @@
             }
         },
         "@babel/helper-explode-assignable-expression": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
-            "integrity": "sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==",
+            "version": "7.11.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
+            "integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.10.4",
                 "@babel/types": "^7.10.4"
             }
         },
@@ -239,15 +238,14 @@
             }
         },
         "@babel/helper-remap-async-to-generator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
-            "integrity": "sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==",
+            "version": "7.11.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
+            "integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.10.4",
                 "@babel/helper-wrap-function": "^7.10.4",
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
                 "@babel/types": "^7.10.4"
             }
         },
@@ -332,9 +330,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.11.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.3.tgz",
-            "integrity": "sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+            "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
             "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
@@ -827,9 +825,9 @@
             }
         },
         "@babel/plugin-transform-runtime": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
-            "integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
+            "integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.10.4",
@@ -906,9 +904,9 @@
             }
         },
         "@babel/preset-env": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-            "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",
+            "integrity": "sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==",
             "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.11.0",
@@ -973,7 +971,7 @@
                 "@babel/plugin-transform-unicode-escapes": "^7.10.4",
                 "@babel/plugin-transform-unicode-regex": "^7.10.4",
                 "@babel/preset-modules": "^0.1.3",
-                "@babel/types": "^7.11.0",
+                "@babel/types": "^7.11.5",
                 "browserslist": "^4.12.0",
                 "core-js-compat": "^3.6.2",
                 "invariant": "^2.2.2",
@@ -982,9 +980,9 @@
             }
         },
         "@babel/preset-modules": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
-            "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+            "integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
@@ -1015,29 +1013,29 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
-            "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+            "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.0",
+                "@babel/generator": "^7.11.5",
                 "@babel/helper-function-name": "^7.10.4",
                 "@babel/helper-split-export-declaration": "^7.11.0",
-                "@babel/parser": "^7.11.0",
-                "@babel/types": "^7.11.0",
+                "@babel/parser": "^7.11.5",
+                "@babel/types": "^7.11.5",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.19"
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -1049,14 +1047,38 @@
             }
         },
         "@babel/types": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-            "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+            "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
             "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.10.4",
                 "lodash": "^4.17.19",
                 "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@chartisan/chartisan": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@chartisan/chartisan/-/chartisan-3.2.3.tgz",
+            "integrity": "sha512-bSb0pVkjpmD+7Jg0qY3c0Km2u6NWzthNspGv6K6laGIrBuL8ETuk7ba1SXzD9Kp7R89Ah85wfgElV0su5aYJiQ==",
+            "requires": {
+                "deepmerge": "^4.2.2"
+            },
+            "dependencies": {
+                "deepmerge": {
+                    "version": "4.2.2",
+                    "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+                    "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+                }
+            }
+        },
+        "@chartisan/echarts": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@chartisan/echarts/-/echarts-2.2.3.tgz",
+            "integrity": "sha512-9TSPBBW61HhDsTmXhivGh6cov3MOYKTiw02+EDnRsCWCayDQ53Imsio8KcNxv7ba8jI+ltFJl2umgZ/96FON+A==",
+            "requires": {
+                "@chartisan/chartisan": "^3.0.5",
+                "resize-observer": "^1.0.0"
             }
         },
         "@mrmlnc/readdir-enhanced": {
@@ -1073,6 +1095,12 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+            "dev": true
+        },
+        "@types/color-name": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
         },
         "@types/glob": {
@@ -1098,9 +1126,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.0.27",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-            "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
+            "version": "14.11.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+            "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
             "dev": true
         },
         "@types/q": {
@@ -1425,9 +1453,9 @@
             }
         },
         "aggregate-error": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-            "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
             "dev": true,
             "requires": {
                 "clean-stack": "^2.0.0",
@@ -1585,14 +1613,15 @@
             "dev": true
         },
         "asn1.js": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
                 "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
             },
             "dependencies": {
                 "bn.js": {
@@ -1872,9 +1901,9 @@
             "dev": true
         },
         "bn.js": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-            "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+            "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
             "dev": true
         },
         "body-parser": {
@@ -1930,6 +1959,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+            "dev": true
+        },
+        "bootstrap": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.2.tgz",
+            "integrity": "sha512-vlGn0bcySYl/iV+BGA544JkkZP5LB3jsmkeKLFQakCOwCM3AOk7VkldBz4jrzSe+Z0Ezn99NVXa1o45cQY4R6A==",
             "dev": true
         },
         "brace-expansion": {
@@ -2084,15 +2119,15 @@
             }
         },
         "browserslist": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.0.tgz",
-            "integrity": "sha512-pUsXKAF2lVwhmtpeA3LJrZ76jXuusrNyhduuQs7CDFf9foT4Y38aQOserd2lMe5DSSrjf3fx34oHwryuvxAUgQ==",
+            "version": "4.14.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
+            "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001111",
-                "electron-to-chromium": "^1.3.523",
-                "escalade": "^3.0.2",
-                "node-releases": "^1.1.60"
+                "caniuse-lite": "^1.0.30001135",
+                "electron-to-chromium": "^1.3.571",
+                "escalade": "^3.1.0",
+                "node-releases": "^1.1.61"
             }
         },
         "buffer": {
@@ -2238,9 +2273,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001112",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001112.tgz",
-            "integrity": "sha512-J05RTQlqsatidif/38aN3PGULCLrg8OYQOlJUKbeYVzC2mGZkZLIztwRlB3MtrfLmawUmjFlNJvy/uhwniIe1Q==",
+            "version": "1.0.30001142",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001142.tgz",
+            "integrity": "sha512-pDPpn9ankEpBFZXyCv2I4lh1v/ju+bqb78QfKf+w9XgDAFWBwSYPswXqprRdrgQWK0wQnpIbfwRjNHO1HWqvoQ==",
             "dev": true
         },
         "chalk": {
@@ -2412,12 +2447,6 @@
                 "q": "^1.1.2"
             }
         },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "dev": true
-        },
         "collect.js": {
             "version": "4.28.2",
             "resolved": "https://registry.npmjs.org/collect.js/-/collect.js-4.28.2.tgz",
@@ -2476,9 +2505,9 @@
             "dev": true
         },
         "commander": {
-            "version": "2.17.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-            "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
         "commondir": {
@@ -2537,6 +2566,15 @@
                 }
             }
         },
+        "concat": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/concat/-/concat-1.0.3.tgz",
+            "integrity": "sha1-QPM1MInWVGdpXLGIa0Xt1jfYzKg=",
+            "dev": true,
+            "requires": {
+                "commander": "^2.9.0"
+            }
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2553,15 +2591,6 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^2.2.2",
                 "typedarray": "^0.0.6"
-            }
-        },
-        "concatenate": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/concatenate/-/concatenate-0.0.2.tgz",
-            "integrity": "sha1-C0nW6MQQR9dyjNyNYqCGYjOXtJ8=",
-            "dev": true,
-            "requires": {
-                "globs": "^0.1.2"
             }
         },
         "connect-history-api-fallback": {
@@ -2901,9 +2930,9 @@
             }
         },
         "css-what": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz",
-            "integrity": "sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.1.tgz",
+            "integrity": "sha512-wHOppVDKl4vTAOWzJt5Ek37Sgd9qq1Bmj/T1OjvicWbU5W7ru7Pqbn0Jdqii3Drx/h+dixHKXNhZYx7blthL7g==",
             "dev": true
         },
         "cssesc": {
@@ -3288,9 +3317,9 @@
             },
             "dependencies": {
                 "domelementtype": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-                    "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+                    "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
                     "dev": true
                 }
             }
@@ -3318,9 +3347,9 @@
             }
         },
         "dot-prop": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-            "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
             "dev": true,
             "requires": {
                 "is-obj": "^2.0.0"
@@ -3350,6 +3379,14 @@
                 "stream-shift": "^1.0.0"
             }
         },
+        "echarts": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/echarts/-/echarts-4.9.0.tgz",
+            "integrity": "sha512-+ugizgtJ+KmsJyyDPxaw2Br5FqzuBnyOWwcxPKO6y0gc5caYcfnEUIlNStx02necw8jmKmTafmpHhGo4XDtEIA==",
+            "requires": {
+                "zrender": "4.3.2"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3357,9 +3394,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.526",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.526.tgz",
-            "integrity": "sha512-HiroW5ZbGwgT8kCnoEO8qnGjoTPzJxduvV/Vv/wH63eo2N6Zj3xT5fmmaSPAPUM05iN9/5fIEkIg3owTtV6QZg==",
+            "version": "1.3.576",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.576.tgz",
+            "integrity": "sha512-uSEI0XZ//5ic+0NdOqlxp0liCD44ck20OAGyLMSymIWTEAtHKVJi6JM18acOnRgUgX7Q65QqnI+sNncNvIy8ew==",
             "dev": true
         },
         "elliptic": {
@@ -3469,20 +3506,21 @@
             }
         },
         "es-abstract": {
-            "version": "1.17.6",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-            "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+            "version": "1.18.0-next.1",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+            "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
             "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1",
-                "is-callable": "^1.2.0",
-                "is-regex": "^1.1.0",
-                "object-inspect": "^1.7.0",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.0",
+                "object.assign": "^4.1.1",
                 "string.prototype.trimend": "^1.0.1",
                 "string.prototype.trimstart": "^1.0.1"
             }
@@ -3541,9 +3579,9 @@
             }
         },
         "escalade": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
-            "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+            "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
             "dev": true
         },
         "escape-html": {
@@ -3575,12 +3613,20 @@
             "dev": true
         },
         "esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
+                }
             }
         },
         "estraverse": {
@@ -3602,9 +3648,9 @@
             "dev": true
         },
         "eventemitter3": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-            "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "dev": true
         },
         "events": {
@@ -4399,15 +4445,6 @@
                 }
             }
         },
-        "globs": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/globs/-/globs-0.1.4.tgz",
-            "integrity": "sha512-D23dWbOq48vlOraoSigbcQV4tWrnhwk+E/Um2cMuDS3/5dwGmdFeA7L/vAvDhLFlQOTDqHcXh35m/71g2A2WzQ==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.1"
-            }
-        },
         "graceful-fs": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -4628,6 +4665,14 @@
                 "param-case": "2.1.x",
                 "relateurl": "0.2.x",
                 "uglify-js": "3.4.x"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.17.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+                    "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+                    "dev": true
+                }
             }
         },
         "http-deceiver": {
@@ -4781,9 +4826,9 @@
             }
         },
         "img-loader": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/img-loader/-/img-loader-3.0.1.tgz",
-            "integrity": "sha512-0jDJqexgzOuq3zlXwFTBKJlMcaP1uXyl5t4Qu6b1IgXb3IwBDjPfVylBC8vHFIIESDw/S+5QkBbtBrt4T8wESA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/img-loader/-/img-loader-3.0.2.tgz",
+            "integrity": "sha512-rSriLKgvi85Km7ppSF+AEAM3nU4fxpvCkaXtC/IoCEU7jfks55bEANFs0bB9YXYkxY9JurZQIZFtXh5Gue3upw==",
             "dev": true,
             "requires": {
                 "loader-utils": "^1.1.0"
@@ -4898,12 +4943,6 @@
                 "loose-envify": "^1.0.0"
             }
         },
-        "invert-kv": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-            "dev": true
-        },
         "ip": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -4976,9 +5015,9 @@
             "dev": true
         },
         "is-callable": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-            "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+            "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
             "dev": true
         },
         "is-color-stop": {
@@ -5075,6 +5114,12 @@
             "requires": {
                 "is-extglob": "^2.1.1"
             }
+        },
+        "is-negative-zero": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+            "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+            "dev": true
         },
         "is-number": {
             "version": "3.0.0",
@@ -5221,15 +5266,26 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
                 }
             }
+        },
+        "jquery": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+            "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
+            "dev": true
+        },
+        "jquery-mask-plugin": {
+            "version": "1.14.16",
+            "resolved": "https://registry.npmjs.org/jquery-mask-plugin/-/jquery-mask-plugin-1.14.16.tgz",
+            "integrity": "sha512-reywdHlYEkPbzWjTpcc1fk9XQ3PLvO5dzEAVqy8zI7NTF22tB1HbeU3iboZTLdkBEPaWAqeI2HtEjsGQ4roZKw=="
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -5310,9 +5366,9 @@
             "dev": true
         },
         "laravel-mix": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-5.0.4.tgz",
-            "integrity": "sha512-/fkcMdlxhGDBcH+kFDqKONlAfhJinMAWd+fjQ+VLii4UzIeXUF5Q8FbS4+ZrZs9JO3Y1E4KoNq3hMw0t/soahA==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-5.0.5.tgz",
+            "integrity": "sha512-ruogwsrTsmUpZU9x1Whgxh+gcEB/6IFJlL+ZTSrYt1SXfOsi8BgMI2R9RWvQpOyR+40VYl7n7Gsr+sHjfFb90Q==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.2.0",
@@ -5327,7 +5383,7 @@
                 "chokidar": "^2.0.3",
                 "clean-css": "^4.1.3",
                 "collect.js": "^4.12.8",
-                "concatenate": "0.0.2",
+                "concat": "^1.0.3",
                 "css-loader": "^1.0.1",
                 "dotenv": "^6.2.0",
                 "dotenv-expand": "^4.2.0",
@@ -5352,7 +5408,7 @@
                 "webpack-dev-server": "^3.1.14",
                 "webpack-merge": "^4.1.0",
                 "webpack-notifier": "^1.5.1",
-                "yargs": "^12.0.5"
+                "yargs": "^15.4.1"
             }
         },
         "last-call-webpack-plugin": {
@@ -5363,15 +5419,6 @@
             "requires": {
                 "lodash": "^4.17.5",
                 "webpack-sources": "^1.1.0"
-            }
-        },
-        "lcid": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-            "dev": true,
-            "requires": {
-                "invert-kv": "^2.0.0"
             }
         },
         "leven": {
@@ -5451,9 +5498,9 @@
             "dev": true
         },
         "loglevel": {
-            "version": "1.6.8",
-            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
-            "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
+            "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
             "dev": true
         },
         "loose-envify": {
@@ -5496,15 +5543,6 @@
             "requires": {
                 "pify": "^4.0.1",
                 "semver": "^5.6.0"
-            }
-        },
-        "map-age-cleaner": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
-            "requires": {
-                "p-defer": "^1.0.0"
             }
         },
         "map-cache": {
@@ -5555,17 +5593,6 @@
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
-        },
-        "mem": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-            "dev": true,
-            "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
-            }
         },
         "memory-fs": {
             "version": "0.4.1",
@@ -5677,12 +5704,6 @@
             "requires": {
                 "mime-db": "1.44.0"
             }
-        },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
         },
         "minimalistic-assert": {
             "version": "1.0.1",
@@ -5880,9 +5901,9 @@
             }
         },
         "node-forge": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-            "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
             "dev": true
         },
         "node-libs-browser": {
@@ -5949,9 +5970,9 @@
             }
         },
         "node-releases": {
-            "version": "1.1.60",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
-            "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+            "version": "1.1.61",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
+            "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
             "dev": true
         },
         "normalize-path": {
@@ -6004,12 +6025,6 @@
             "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
             "dev": true
         },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
-        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6054,13 +6069,13 @@
             "dev": true
         },
         "object-is": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-            "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+            "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "es-abstract": "^1.18.0-next.1"
             }
         },
         "object-keys": {
@@ -6085,15 +6100,15 @@
             }
         },
         "object.assign": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+            "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.1.1",
-                "has-symbols": "^1.0.0",
-                "object-keys": "^1.0.11"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.0",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
             }
         },
         "object.getownpropertydescriptors": {
@@ -6104,6 +6119,27 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "object.omit": {
@@ -6134,6 +6170,27 @@
                 "es-abstract": "^1.17.0-next.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "obuf": {
@@ -6176,9 +6233,9 @@
             }
         },
         "optimize-css-assets-webpack-plugin": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
-            "integrity": "sha512-q9fbvCRS6EYtUKKSwI87qm2IxlyJK5b4dygW1rKUBT6mMDhdG5e5bZT63v6tnJR9F9FB/H5a0HTmtw+laUBxKA==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.4.tgz",
+            "integrity": "sha512-wqd6FdI2a5/FdoiCNNkEvLeA//lHHfG24Ln2Xm2qqdIk4aOlsR18jwpyOihqQ8849W3qu2DX8fOYxpvTMj+93A==",
             "dev": true,
             "requires": {
                 "cssnano": "^4.1.10",
@@ -6200,33 +6257,10 @@
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
         },
-        "os-locale": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-            "dev": true,
-            "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
-            }
-        },
-        "p-defer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-            "dev": true
-        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
-        },
-        "p-is-promise": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-            "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
             "dev": true
         },
         "p-limit": {
@@ -6304,14 +6338,13 @@
             }
         },
         "parse-asn1": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-            "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+            "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
             "dev": true,
             "requires": {
-                "asn1.js": "^4.0.0",
+                "asn1.js": "^5.2.0",
                 "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
                 "evp_bytestokey": "^1.0.0",
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
@@ -6460,6 +6493,12 @@
                 "find-up": "^3.0.0"
             }
         },
+        "popper.js": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+            "dev": true
+        },
         "portfinder": {
             "version": "1.0.28",
             "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -6495,9 +6534,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "7.0.32",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-            "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+            "version": "7.0.35",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.2",
@@ -6523,9 +6562,9 @@
             }
         },
         "postcss-calc": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.3.tgz",
-            "integrity": "sha512-IB/EAEmZhIMEIhG7Ov4x+l47UaXOS1n2f4FBUk/aKllQhtSCxWhTzn0nJgkqN7fo/jcWySvWTSB6Syk9L+31bA==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.5.tgz",
+            "integrity": "sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==",
             "dev": true,
             "requires": {
                 "postcss": "^7.0.27",
@@ -6609,9 +6648,9 @@
             }
         },
         "postcss-load-config": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
-            "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.2.tgz",
+            "integrity": "sha512-/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==",
             "dev": true,
             "requires": {
                 "cosmiconfig": "^5.0.0",
@@ -7105,14 +7144,15 @@
             }
         },
         "postcss-selector-parser": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-            "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+            "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
                 "indexes-of": "^1.0.1",
-                "uniq": "^1.0.1"
+                "uniq": "^1.0.1",
+                "util-deprecate": "^1.0.2"
             }
         },
         "postcss-svgo": {
@@ -7291,9 +7331,9 @@
             "dev": true
         },
         "querystringify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
             "dev": true
         },
         "randombytes": {
@@ -7433,12 +7473,33 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "regexpu-core": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-            "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+            "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.4.0",
@@ -7519,6 +7580,11 @@
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
             "dev": true
+        },
+        "resize-observer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.0.tgz",
+            "integrity": "sha512-D7UFShDm2TgrEDEyeg+/tTEbvOgPWlvPAfJtxiKp+qutu6HowmcGJKjECgGru0PPDIj3SAucn3ZPpOx54fF7DQ=="
         },
         "resolve": {
             "version": "1.17.0",
@@ -7796,12 +7862,12 @@
             "dev": true
         },
         "selfsigned": {
-            "version": "1.10.7",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-            "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+            "version": "1.10.8",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+            "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
             "dev": true,
             "requires": {
-                "node-forge": "0.9.0"
+                "node-forge": "^0.10.0"
             }
         },
         "semver": {
@@ -7857,9 +7923,9 @@
             }
         },
         "serialize-javascript": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-            "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"
@@ -8279,12 +8345,12 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -8310,12 +8376,12 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -8475,6 +8541,27 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.5"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "string.prototype.trimstart": {
@@ -8485,6 +8572,27 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.5"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "string_decoder": {
@@ -8605,12 +8713,6 @@
                 "source-map-support": "~0.5.10"
             },
             "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
-                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8620,9 +8722,9 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.7.tgz",
-            "integrity": "sha512-xzYyaHUNhzgaAdBsXxk2Yvo/x1NJdslUaussK3fdpBbvttm1iIwU+c26dj9UxJcwk2c5UWt5F55MUTIA8BE7Dg==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz",
+            "integrity": "sha512-/fKw3R+hWyHfYx7Bv6oPqmk4HGQcrWLtV3X6ggvPuwPNHSnzvVV51z6OaaCOus4YLjutYGOz3pEpbhe6Up2s1w==",
             "dev": true,
             "requires": {
                 "cacache": "^13.0.1",
@@ -8630,18 +8732,12 @@
                 "jest-worker": "^25.4.0",
                 "p-limit": "^2.3.0",
                 "schema-utils": "^2.6.6",
-                "serialize-javascript": "^3.1.0",
+                "serialize-javascript": "^4.0.0",
                 "source-map": "^0.6.1",
                 "terser": "^4.6.12",
                 "webpack-sources": "^1.4.3"
             },
             "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
-                },
                 "find-cache-dir": {
                     "version": "3.3.1",
                     "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -9115,6 +9211,27 @@
                 "es-abstract": "^1.17.2",
                 "has-symbols": "^1.0.1",
                 "object.getownpropertydescriptors": "^2.1.0"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "utils-merge": {
@@ -9341,9 +9458,9 @@
             }
         },
         "webpack": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
-            "integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
+            "version": "4.44.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
+            "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
             "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.9.0",
@@ -9394,12 +9511,6 @@
                         "y18n": "^4.0.0"
                     }
                 },
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
-                },
                 "schema-utils": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -9438,16 +9549,16 @@
                     }
                 },
                 "terser-webpack-plugin": {
-                    "version": "1.4.4",
-                    "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
-                    "integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
+                    "version": "1.4.5",
+                    "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+                    "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
                     "dev": true,
                     "requires": {
                         "cacache": "^12.0.2",
                         "find-cache-dir": "^2.1.0",
                         "is-wsl": "^1.1.0",
                         "schema-utils": "^1.0.0",
-                        "serialize-javascript": "^3.1.0",
+                        "serialize-javascript": "^4.0.0",
                         "source-map": "^0.6.1",
                         "terser": "^4.1.2",
                         "webpack-sources": "^1.4.0",
@@ -9642,12 +9753,12 @@
                     "dev": true
                 },
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "is-absolute-url": {
@@ -9890,114 +10001,147 @@
             "dev": true
         },
         "yargs": {
-            "version": "12.0.5",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-            "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
             "dev": true,
             "requires": {
-                "cliui": "^4.0.0",
+                "cliui": "^6.0.0",
                 "decamelize": "^1.2.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^3.0.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
                 "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
+                "require-main-filename": "^2.0.0",
                 "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
+                "string-width": "^4.2.0",
                 "which-module": "^2.0.0",
-                "y18n": "^3.2.1 || ^4.0.0",
-                "yargs-parser": "^11.1.1"
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
                 },
                 "cliui": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+                    "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
                     "dev": true,
                     "requires": {
-                        "string-width": "^2.1.1",
-                        "strip-ansi": "^4.0.0",
-                        "wrap-ansi": "^2.0.0"
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^6.2.0"
                     }
                 },
-                "get-caller-file": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-                    "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
                 },
                 "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "dev": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "require-main-filename": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
                     "dev": true
                 },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
                     }
                 },
                 "wrap-ansi": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
                     "dev": true,
                     "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "2.1.1",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                            "dev": true
-                        },
-                        "string-width": {
-                            "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                            "dev": true,
-                            "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
-                            }
-                        },
-                        "strip-ansi": {
-                            "version": "3.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "^2.0.0"
-                            }
-                        }
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
                     }
                 },
                 "yargs-parser": {
-                    "version": "11.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
                     "dev": true,
                     "requires": {
                         "camelcase": "^5.0.0",
@@ -10015,6 +10159,11 @@
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
             }
+        },
+        "zrender": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/zrender/-/zrender-4.3.2.tgz",
+            "integrity": "sha512-bIusJLS8c4DkIcdiK+s13HiQ/zjQQVgpNohtd8d94Y2DnJqgM1yjh/jpDb8DoL6hd7r8Awagw8e3qK/oLaWr3g=="
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1061,6 +1061,7 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/@chartisan/chartisan/-/chartisan-3.2.3.tgz",
             "integrity": "sha512-bSb0pVkjpmD+7Jg0qY3c0Km2u6NWzthNspGv6K6laGIrBuL8ETuk7ba1SXzD9Kp7R89Ah85wfgElV0su5aYJiQ==",
+            "dev": true,
             "requires": {
                 "deepmerge": "^4.2.2"
             },
@@ -1068,7 +1069,8 @@
                 "deepmerge": {
                     "version": "4.2.2",
                     "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-                    "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+                    "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+                    "dev": true
                 }
             }
         },
@@ -1076,6 +1078,7 @@
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/@chartisan/echarts/-/echarts-2.2.3.tgz",
             "integrity": "sha512-9TSPBBW61HhDsTmXhivGh6cov3MOYKTiw02+EDnRsCWCayDQ53Imsio8KcNxv7ba8jI+ltFJl2umgZ/96FON+A==",
+            "dev": true,
             "requires": {
                 "@chartisan/chartisan": "^3.0.5",
                 "resize-observer": "^1.0.0"
@@ -1711,15 +1714,6 @@
                 "num2fraction": "^1.2.2",
                 "postcss": "^7.0.32",
                 "postcss-value-parser": "^4.1.0"
-            }
-        },
-        "axios": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-            "dev": true,
-            "requires": {
-                "follow-redirects": "1.5.10"
             }
         },
         "babel-code-frame": {
@@ -3383,6 +3377,7 @@
             "version": "4.9.0",
             "resolved": "https://registry.npmjs.org/echarts/-/echarts-4.9.0.tgz",
             "integrity": "sha512-+ugizgtJ+KmsJyyDPxaw2Br5FqzuBnyOWwcxPKO6y0gc5caYcfnEUIlNStx02necw8jmKmTafmpHhGo4XDtEIA==",
+            "dev": true,
             "requires": {
                 "zrender": "4.3.2"
             }
@@ -5285,7 +5280,8 @@
         "jquery-mask-plugin": {
             "version": "1.14.16",
             "resolved": "https://registry.npmjs.org/jquery-mask-plugin/-/jquery-mask-plugin-1.14.16.tgz",
-            "integrity": "sha512-reywdHlYEkPbzWjTpcc1fk9XQ3PLvO5dzEAVqy8zI7NTF22tB1HbeU3iboZTLdkBEPaWAqeI2HtEjsGQ4roZKw=="
+            "integrity": "sha512-reywdHlYEkPbzWjTpcc1fk9XQ3PLvO5dzEAVqy8zI7NTF22tB1HbeU3iboZTLdkBEPaWAqeI2HtEjsGQ4roZKw==",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -5439,7 +5435,8 @@
         "lightbox2": {
             "version": "2.11.3",
             "resolved": "https://registry.npmjs.org/lightbox2/-/lightbox2-2.11.3.tgz",
-            "integrity": "sha512-Q4v6il/OK9ttgEkAxSok/jrI/LUbqTrePFchqP2x/59qaDIZgJjEEc5Xf7peSMc/55Zo5PAgmX6EiN/BeEeUBQ=="
+            "integrity": "sha512-Q4v6il/OK9ttgEkAxSok/jrI/LUbqTrePFchqP2x/59qaDIZgJjEEc5Xf7peSMc/55Zo5PAgmX6EiN/BeEeUBQ==",
+            "dev": true
         },
         "loader-runner": {
             "version": "2.4.0",
@@ -7584,7 +7581,8 @@
         "resize-observer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.0.tgz",
-            "integrity": "sha512-D7UFShDm2TgrEDEyeg+/tTEbvOgPWlvPAfJtxiKp+qutu6HowmcGJKjECgGru0PPDIj3SAucn3ZPpOx54fF7DQ=="
+            "integrity": "sha512-D7UFShDm2TgrEDEyeg+/tTEbvOgPWlvPAfJtxiKp+qutu6HowmcGJKjECgGru0PPDIj3SAucn3ZPpOx54fF7DQ==",
+            "dev": true
         },
         "resolve": {
             "version": "1.17.0",
@@ -10163,7 +10161,8 @@
         "zrender": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/zrender/-/zrender-4.3.2.tgz",
-            "integrity": "sha512-bIusJLS8c4DkIcdiK+s13HiQ/zjQQVgpNohtd8d94Y2DnJqgM1yjh/jpDb8DoL6hd7r8Awagw8e3qK/oLaWr3g=="
+            "integrity": "sha512-bIusJLS8c4DkIcdiK+s13HiQ/zjQQVgpNohtd8d94Y2DnJqgM1yjh/jpDb8DoL6hd7r8Awagw8e3qK/oLaWr3g==",
+            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -11,15 +11,21 @@
     },
     "devDependencies": {
         "axios": "^0.19",
+        "bootstrap": "^4.0.0",
         "cross-env": "^7.0",
-        "laravel-mix": "^5.0.1",
+        "jquery": "^3.2",
+        "laravel-mix": "^5.0.5",
         "lodash": "^4.17.13",
+        "popper.js": "^1.12",
         "resolve-url-loader": "^3.1.0",
         "sass": "^1.15.2",
         "sass-loader": "^8.0.0",
         "vue-template-compiler": "^2.6.12"
     },
     "dependencies": {
+        "@chartisan/echarts": "^2.2.3",
+        "echarts": "^4.9.0",
+        "jquery-mask-plugin": "^1.14.16",
         "lightbox2": "^2.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,19 +10,15 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
-        "axios": "^0.19",
         "bootstrap": "^4.0.0",
         "cross-env": "^7.0",
         "jquery": "^3.2",
         "laravel-mix": "^5.0.5",
-        "lodash": "^4.17.13",
         "popper.js": "^1.12",
         "resolve-url-loader": "^3.1.0",
         "sass": "^1.15.2",
         "sass-loader": "^8.0.0",
-        "vue-template-compiler": "^2.6.12"
-    },
-    "dependencies": {
+        "vue-template-compiler": "^2.6.12",
         "@chartisan/echarts": "^2.2.3",
         "echarts": "^4.9.0",
         "jquery-mask-plugin": "^1.14.16",

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,3 +1,0 @@
-.hide{
-    display: none!important;
-}

--- a/public/js/pages/training_create.js
+++ b/public/js/pages/training_create.js
@@ -67,7 +67,7 @@ function getDay(index){
 
 function handleAuxiliaries(id){
   if(!id){
-      auxiliaryForm.classList.remove('hide');
+      auxiliaryForm.classList.remove('d-none');
       auxiliaryTitle.textContent = "Ajudantes:";
       return;
   }
@@ -76,9 +76,9 @@ function handleAuxiliaries(id){
       auxiliary1.value= null;
       auxiliary2.value= null;
       auxiliaryTitle.textContent = "Essa turma não necessita ajudantes!";
-      auxiliaryForm.classList.add('hide');
+      auxiliaryForm.classList.add('d-none');
   } else {
-      auxiliaryForm.classList.remove('hide');
+      auxiliaryForm.classList.remove('d-none');
       auxiliaryTitle.textContent = "Ajudantes:";
   }
 }

--- a/public/js/pages/training_edit.js
+++ b/public/js/pages/training_edit.js
@@ -52,7 +52,7 @@ setDay();
 
   function handleAuxiliaries(id){
     if(!id){
-        auxiliaryForm.classList.remove('hide');
+        auxiliaryForm.classList.remove('d-none');
         auxiliaryTitle.textContent = "Ajudantes:";
         return;
     }
@@ -61,9 +61,9 @@ setDay();
         auxiliary1.value= null;
         auxiliary2.value= null;
         auxiliaryTitle.textContent = "Essa turma não necessita ajudantes!";
-        auxiliaryForm.classList.add('hide');
+        auxiliaryForm.classList.add('d-none');
     } else {
-        auxiliaryForm.classList.remove('hide');
+        auxiliaryForm.classList.remove('d-none');
         auxiliaryTitle.textContent = "Ajudantes:";
     }
   }

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,15 +1,9 @@
-window._ = require('lodash');
-
 try {
+    window.Chartisan = require('@chartisan/echarts').Chartisan;
     window.Popper = require('popper.js').default;
     window.$ = window.jQuery = require('jquery');
 
     require('jquery-mask-plugin');
     require('bootstrap');
+    require('lightbox2');
 } catch (e) {}
-
-window.Chartisan = require('@chartisan/echarts').Chartisan;
-
-window.axios = require('axios');
-
-window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,30 +1,15 @@
-window._ = require("lodash");
+window._ = require('lodash');
 
-/**
- * We'll load the axios HTTP library which allows us to easily issue requests
- * to our Laravel back-end. This library automatically handles sending the
- * CSRF token as a header based on the value of the "XSRF" token cookie.
- */
+try {
+    window.Popper = require('popper.js').default;
+    window.$ = window.jQuery = require('jquery');
 
-window.axios = require("axios");
+    require('jquery-mask-plugin');
+    require('bootstrap');
+} catch (e) {}
 
-window.axios.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest";
+window.Chartisan = require('@chartisan/echarts').Chartisan;
 
-/**
- * Echo exposes an expressive API for subscribing to channels and listening
- * for events that are broadcast by Laravel. Echo and event broadcasting
- * allows your team to easily build robust real-time web applications.
- */
+window.axios = require('axios');
 
-// import Echo from 'laravel-echo';
-
-// window.Pusher = require('pusher-js');
-
-// window.Echo = new Echo({
-//     broadcaster: 'pusher',
-//     key: process.env.MIX_PUSHER_APP_KEY,
-//     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
-//     forceTLS: true
-// });
-
-try { window.Popper = require('popper.js').default; window.$ = window.jQuery = require('jquery'); require('bootstrap'); require('lightbox2'); } catch (e) { }
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';

--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -2,7 +2,7 @@
 $body-bg: #f8fafc;
 
 // Typography
-// $font-family-sans-serif: 'Nunito', sans-serif;
+$font-family-sans-serif: 'Nunito', sans-serif;
 $font-size-base: 0.9rem;
 $line-height-base: 1.6;
 

--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -2,7 +2,7 @@
 $body-bg: #f8fafc;
 
 // Typography
-$font-family-sans-serif: 'Nunito', sans-serif;
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $font-size-base: 0.9rem;
 $line-height-base: 1.6;
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1,8 +1,8 @@
-// Fonts
-@import url('https://fonts.googleapis.com/css?family=Nunito');
-
 // Variables
 @import 'variables';
 
 // Bootstrap
 @import '~bootstrap/scss/bootstrap';
+
+// Lightbox2
+@import '~lightbox2/dist/css/lightbox';

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -3,9 +3,6 @@
 
 // Variables
 @import 'variables';
-// Variables
-@import 'custom';
 
-
-// Lightbox2
-@import '~lightbox2/dist/css/lightbox';
+// Bootstrap
+@import '~bootstrap/scss/bootstrap';

--- a/resources/sass/custom.scss
+++ b/resources/sass/custom.scss
@@ -1,3 +1,0 @@
-a.nav-link.active{
-    background: #ddd;
-}

--- a/resources/views/athlete_evaluation_chart/index.blade.php
+++ b/resources/views/athlete_evaluation_chart/index.blade.php
@@ -67,13 +67,6 @@
 @endsection
 
 @section('script')
-<!-- Charting library -->
-<script src="https://unpkg.com/echarts/dist/echarts.min.js"></script>
-<!-- Chartisan -->
-<script src="https://unpkg.com/@chartisan/echarts/dist/chartisan_echarts.js"></script>
-<!-- Bootstrap -->
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-
 <script>
 (function(document) {
 

--- a/resources/views/athletes/create.blade.php
+++ b/resources/views/athletes/create.blade.php
@@ -116,12 +116,10 @@
 @endsection
 
 @section('script')
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js" defer></script>
 <script>
   $(document).ready(function() {
     $('#telephone').mask('(00)00000-0000');
     $('#rg').mask('0.000.000');
   });
-
 </script>
 @endsection

--- a/resources/views/athletes/edit.blade.php
+++ b/resources/views/athletes/edit.blade.php
@@ -123,7 +123,6 @@
 @endsection
 
 @section('script')
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js" defer></script>
 <script>
   $(document).ready(function() {
     $('#telephone').mask('(00)00000-0000');

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,10 +11,8 @@ if($user){
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <link rel="stylesheet" href="{{ asset('css/styles.css') }}">
     <title>IBAD</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-        integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
+    <link rel="stylesheet" href="{{ asset('css/app.css') }}">
 </head>
 <body>
     <div id="app">
@@ -157,16 +155,6 @@ if($user){
         </main>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
-        integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous">
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
-        integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous">
-    </script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"
-        integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous">
-    </script>
-
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="{{ asset('js/app.js') }}"></script>
     @yield('script')
 </body>

--- a/resources/views/queryathlete/show.blade.php
+++ b/resources/views/queryathlete/show.blade.php
@@ -78,9 +78,8 @@
 @endsection
 
 @section('script')
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js" defer></script>
 <script>
-    $(document).ready(function() {
+  $(document).ready(function() {
     $('#telephone').mask('(00)00000-0000');
     $('#rg').mask('0.000.000');
   });

--- a/resources/views/responsibles/create.blade.php
+++ b/resources/views/responsibles/create.blade.php
@@ -57,6 +57,5 @@
 @endsection
 
 @section('script')
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js" defer></script>
 <script src="{{ asset('js/pages/responsibles.js') }}"></script>
 @endsection

--- a/resources/views/responsibles/edit.blade.php
+++ b/resources/views/responsibles/edit.blade.php
@@ -70,6 +70,5 @@
 @endsection
 
 @section('script')
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js" defer></script>
 <script src="{{ asset('js/pages/responsibles.js') }}"></script>
 @endsection


### PR DESCRIPTION
Altera a importação de dependências externas do frontend, utilizando o padrão especificado na [documentação do Laravel](https://laravel.com/docs/7.x/frontend), de modo que as dependências sejam compiladas um um único arquivo JS e um único arquivo CSS.